### PR TITLE
Share atlas between text renderers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "8e62ca0" }
 fontdue = "0.7.2"
 etagere = "0.2.6"
-pollster = "0.2.5"
 
 [dev-dependencies]
 winit = "0.26.1"
+pollster = "0.2.5"

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -3,7 +3,7 @@ use glyphon::{
         layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle},
         Font, FontSettings,
     },
-    Color, HasColor, Resolution, TextRenderer,
+    Color, HasColor, Resolution, TextAtlas, TextRenderer,
 };
 use wgpu::{
     Backends, CommandEncoderDescriptor, DeviceDescriptor, Features, Instance, Limits, LoadOp,
@@ -66,7 +66,8 @@ async fn run() {
     };
     surface.configure(&device, &config);
 
-    let mut text_renderer = TextRenderer::new(&device, &queue, swapchain_format);
+    let atlas = TextAtlas::new(&device, &queue, swapchain_format);
+    let mut text_renderer = TextRenderer::new(&device, &queue, &atlas);
 
     let font = include_bytes!("./Inter-Bold.ttf") as &[u8];
     let font = Font::from_bytes(font, FontSettings::default()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ fn try_allocate(atlas: &mut InnerAtlas, width: usize, height: usize) -> Option<A
         }
 
         // Try to free least recently used allocation
-        let (key, value) = atlas.glyph_cache.entries_least_recently_used().next()?;
+        let (key, value) = atlas.glyph_cache.pop()?;
         atlas
             .packer
             .deallocate(value.atlas_id.expect("cache corrupt"));

--- a/src/recently_used.rs
+++ b/src/recently_used.rs
@@ -1,0 +1,127 @@
+use std::{
+    borrow::Borrow,
+    collections::{hash_map::Entry, HashMap},
+    hash::Hash,
+};
+
+struct RecentlyUsedItem<V> {
+    entry_idx: usize,
+    value: V,
+}
+
+pub struct RecentlyUsedMap<K: Clone + Copy + Eq + Hash, V> {
+    keys: Vec<K>,
+    map: HashMap<K, RecentlyUsedItem<V>>,
+}
+
+impl<K: Clone + Copy + Eq + Hash, V> RecentlyUsedMap<K, V> {
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            keys: Vec::with_capacity(capacity),
+            map: HashMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        let new_idx = self.keys.len();
+        match self.map.entry(key) {
+            Entry::Occupied(mut occupied) => {
+                let old = occupied.insert(RecentlyUsedItem {
+                    entry_idx: new_idx,
+                    value,
+                });
+                let removed = self.keys.remove(old.entry_idx);
+                self.keys.push(removed);
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(RecentlyUsedItem {
+                    entry_idx: new_idx,
+                    value,
+                });
+                self.keys.push(key);
+            }
+        }
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        if let Some(entry) = self.map.remove(key.borrow()) {
+            self.keys.remove(entry.entry_idx);
+        }
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.map.get(k).map(|item| &item.value)
+    }
+
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.map.contains_key(k)
+    }
+
+    pub fn entries_least_recently_used(&self) -> impl Iterator<Item = (K, &V)> + '_ {
+        self.keys.iter().map(|k| (*k, &self.map[k].value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert() {
+        let mut rus = RecentlyUsedMap::new();
+        rus.insert("a", ());
+        rus.insert("b", ());
+        assert_eq!(
+            rus.entries_least_recently_used()
+                .map(|(k, _)| k)
+                .collect::<String>(),
+            "ab"
+        );
+    }
+
+    #[test]
+    fn reinsert() {
+        let mut rus = RecentlyUsedMap::new();
+        rus.insert("a", ());
+        rus.insert("b", ());
+        rus.insert("c", ());
+        rus.insert("a", ());
+        assert_eq!(
+            rus.entries_least_recently_used()
+                .map(|(k, _)| k)
+                .collect::<String>(),
+            "bca"
+        );
+    }
+
+    #[test]
+    fn remove() {
+        let mut rus = RecentlyUsedMap::new();
+        rus.insert("a", ());
+        rus.insert("b", ());
+        rus.remove("a");
+        rus.remove("c");
+        assert_eq!(
+            rus.entries_least_recently_used()
+                .map(|(k, _)| k)
+                .collect::<String>(),
+            "b"
+        );
+    }
+}

--- a/src/recently_used.rs
+++ b/src/recently_used.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap},
-    fmt,
     hash::Hash,
 };
 
@@ -10,7 +9,6 @@ struct RecentlyUsedItem<V> {
     value: V,
 }
 
-#[derive(Debug)]
 enum Node<V> {
     Value {
         value: V,
@@ -30,7 +28,7 @@ pub struct RecentlyUsedMap<K: Clone + Copy + Eq + Hash, V> {
     free: Option<usize>,
 }
 
-impl<K: Clone + Copy + Eq + Hash + fmt::Debug, V> RecentlyUsedMap<K, V> {
+impl<K: Clone + Copy + Eq + Hash, V> RecentlyUsedMap<K, V> {
     pub fn new() -> Self {
         Self::with_capacity(0)
     }

--- a/src/recently_used.rs
+++ b/src/recently_used.rs
@@ -1,60 +1,175 @@
 use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap},
+    fmt,
     hash::Hash,
 };
 
 struct RecentlyUsedItem<V> {
-    entry_idx: usize,
+    node_idx: usize,
     value: V,
 }
 
-pub struct RecentlyUsedMap<K: Clone + Copy + Eq + Hash, V> {
-    keys: Vec<K>,
-    map: HashMap<K, RecentlyUsedItem<V>>,
+#[derive(Debug)]
+enum Node<V> {
+    Value {
+        value: V,
+        prev_idx: Option<usize>,
+        next_idx: Option<usize>,
+    },
+    Free {
+        next_idx: Option<usize>,
+    },
 }
 
-impl<K: Clone + Copy + Eq + Hash, V> RecentlyUsedMap<K, V> {
+pub struct RecentlyUsedMap<K: Clone + Copy + Eq + Hash, V> {
+    nodes: Vec<Node<K>>,
+    least_recent_idx: Option<usize>,
+    most_recent_idx: Option<usize>,
+    map: HashMap<K, RecentlyUsedItem<V>>,
+    free: Option<usize>,
+}
+
+impl<K: Clone + Copy + Eq + Hash + fmt::Debug, V> RecentlyUsedMap<K, V> {
     pub fn new() -> Self {
         Self::with_capacity(0)
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
+        assert!(capacity < usize::MAX - 1, "capacity too large");
         Self {
-            keys: Vec::with_capacity(capacity),
+            nodes: Vec::with_capacity(capacity),
+            least_recent_idx: None,
+            most_recent_idx: None,
+            free: None,
             map: HashMap::with_capacity(capacity),
         }
     }
 
-    pub fn insert(&mut self, key: K, value: V) {
-        let new_idx = self.keys.len();
-        match self.map.entry(key) {
-            Entry::Occupied(mut occupied) => {
-                let old = occupied.insert(RecentlyUsedItem {
-                    entry_idx: new_idx,
-                    value,
-                });
-                let removed = self.keys.remove(old.entry_idx);
-                self.keys.push(removed);
+    fn allocate_node(&mut self, node: Node<K>) -> usize {
+        match self.free {
+            Some(idx) => {
+                // Reuse a node from storage
+                match self.nodes[idx] {
+                    Node::Free { next_idx } => {
+                        self.free = next_idx;
+                    }
+                    Node::Value { .. } => unreachable!(),
+                }
+
+                self.nodes[idx] = node;
+
+                idx
             }
-            Entry::Vacant(vacant) => {
-                vacant.insert(RecentlyUsedItem {
-                    entry_idx: new_idx,
-                    value,
-                });
-                self.keys.push(key);
+            None => {
+                // Create a new storage node
+                self.nodes.push(node);
+                self.nodes.len() - 1
             }
         }
     }
 
-    pub fn remove<Q: ?Sized>(&mut self, key: &Q)
+    pub fn insert(&mut self, key: K, value: V) {
+        let new_idx = self.allocate_node(Node::Value {
+            value: key,
+            prev_idx: self.most_recent_idx,
+            next_idx: None,
+        });
+
+        let prior_most_recent = self.most_recent_idx.map(|idx| &mut self.nodes[idx]);
+        match prior_most_recent {
+            Some(p) => {
+                // Update prior most recent if one exists
+                match p {
+                    Node::Value { next_idx, .. } => {
+                        *next_idx = Some(new_idx);
+                    }
+                    Node::Free { .. } => unreachable!(),
+                }
+            }
+            None => {
+                // Update least recent if this is the first node
+                self.least_recent_idx = Some(new_idx);
+            }
+        }
+
+        self.most_recent_idx = Some(new_idx);
+
+        match self.map.entry(key) {
+            Entry::Occupied(mut occupied) => {
+                let old = occupied.insert(RecentlyUsedItem {
+                    node_idx: new_idx,
+                    value,
+                });
+
+                // Remove the old occurrence of this key
+                self.remove_node(old.node_idx);
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(RecentlyUsedItem {
+                    node_idx: new_idx,
+                    value,
+                });
+            }
+        }
+    }
+
+    fn remove_node(&mut self, idx: usize) {
+        match self.nodes[idx] {
+            Node::Value {
+                prev_idx, next_idx, ..
+            } => {
+                match prev_idx {
+                    Some(prev) => match &mut self.nodes[prev] {
+                        Node::Value {
+                            next_idx: old_next_idx,
+                            ..
+                        } => {
+                            *old_next_idx = next_idx;
+                        }
+                        Node::Free { .. } => unreachable!(),
+                    },
+                    None => {
+                        // This node was the least recent
+                        self.least_recent_idx = next_idx;
+                    }
+                }
+
+                match next_idx {
+                    Some(next) => match &mut self.nodes[next] {
+                        Node::Value {
+                            prev_idx: old_prev_idx,
+                            ..
+                        } => {
+                            *old_prev_idx = prev_idx;
+                        }
+                        Node::Free { .. } => unreachable!(),
+                    },
+                    None => {
+                        // This node was the most recent
+                        self.most_recent_idx = prev_idx;
+                    }
+                }
+            }
+            Node::Free { .. } => unreachable!(),
+        }
+
+        // Add to free list
+        self.nodes[idx] = Node::Free {
+            next_idx: self.free,
+        };
+        self.free = Some(idx);
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        if let Some(entry) = self.map.remove(key.borrow()) {
-            self.keys.remove(entry.entry_idx);
-        }
+        self.map.remove(key.borrow()).map(|entry| {
+            self.remove_node(entry.node_idx);
+            entry.value
+        })
     }
 
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
@@ -73,8 +188,17 @@ impl<K: Clone + Copy + Eq + Hash, V> RecentlyUsedMap<K, V> {
         self.map.contains_key(k)
     }
 
-    pub fn entries_least_recently_used(&self) -> impl Iterator<Item = (K, &V)> + '_ {
-        self.keys.iter().map(|k| (*k, &self.map[k].value))
+    pub fn pop(&mut self) -> Option<(K, V)> {
+        let least_recent_idx = self.least_recent_idx?;
+        let least_recent_node = &self.nodes[least_recent_idx];
+
+        match *least_recent_node {
+            Node::Value { value: key, .. } => {
+                let value = self.remove(&key);
+                value.map(|v| (key, v))
+            }
+            Node::Free { .. } => unreachable!(),
+        }
     }
 }
 
@@ -87,12 +211,11 @@ mod tests {
         let mut rus = RecentlyUsedMap::new();
         rus.insert("a", ());
         rus.insert("b", ());
-        assert_eq!(
-            rus.entries_least_recently_used()
-                .map(|(k, _)| k)
-                .collect::<String>(),
-            "ab"
-        );
+        rus.insert("c", ());
+        assert_eq!(rus.pop(), Some(("a", ())));
+        assert_eq!(rus.pop(), Some(("b", ())));
+        assert_eq!(rus.pop(), Some(("c", ())));
+        assert_eq!(rus.pop(), None);
     }
 
     #[test]
@@ -102,12 +225,10 @@ mod tests {
         rus.insert("b", ());
         rus.insert("c", ());
         rus.insert("a", ());
-        assert_eq!(
-            rus.entries_least_recently_used()
-                .map(|(k, _)| k)
-                .collect::<String>(),
-            "bca"
-        );
+        assert_eq!(rus.pop(), Some(("b", ())));
+        assert_eq!(rus.pop(), Some(("c", ())));
+        assert_eq!(rus.pop(), Some(("a", ())));
+        assert_eq!(rus.pop(), None);
     }
 
     #[test]
@@ -117,11 +238,22 @@ mod tests {
         rus.insert("b", ());
         rus.remove("a");
         rus.remove("c");
-        assert_eq!(
-            rus.entries_least_recently_used()
-                .map(|(k, _)| k)
-                .collect::<String>(),
-            "b"
-        );
+        assert_eq!(rus.pop(), Some(("b", ())));
+        assert_eq!(rus.pop(), None);
+    }
+
+    #[test]
+    fn reuses_free_nodes() {
+        let mut rus = RecentlyUsedMap::new();
+        rus.insert("a", ());
+        rus.insert("b", ());
+        rus.insert("c", ());
+        rus.remove("b");
+        rus.remove("c");
+        rus.remove("a");
+        rus.insert("d", ());
+        rus.insert("e", ());
+        rus.insert("f", ());
+        assert_eq!(rus.nodes.len(), 3);
     }
 }


### PR DESCRIPTION
This allows the glyph cache to be shared between renderers.

Fixes #6

For now, we also reuse some other fields where possible (e.g. params, bind groups). We could change this later if we'd any of these to vary between renderers.

This doesn't change the storage, so a single 2D texture is still used for now.

Some other ideas:
- We could empty the cache easily if we had an `Arc` per glyph to know if it needs to remain in the cache. This would probably be really heavyweight and we'd need to change the refcount per glyph every time `prepare` is called, so I avoided this approach.
- Pass `layouts` into `render` and verify the glyphs  exist instead of storing them in a `Vec` on `TextRenderer`. I didn't do it this way because `layouts` can change between `prepare` and `render`, although maybe we could require that it's not allowed (e.g. through documentation or lifetimes).
- We could generate an atlas internally if we don't want to require the atlas to be passed in explicitly in all `new` functions (e.g. builders or `Default`). This would make the shared atlas opt-in but it seems like we'd probably want the opt-in behavior by default.
- We could accept `&mut TextAtlas` where we need to use the atlas instead of internally storing `Arc<RwLock<InnerAtlas>>`. This avoids `Arc` and `RwLock` to be replaced by something else (e.g. `Rc` when running single-threaded). Doing it internally seems to have better ergonomics because we don't have to pass in `&mut TextAtlas` all the time, but there's a good argument for keeping this external too.