### PR TITLE
Accept atlas in `prepare` and `render`

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -66,8 +66,8 @@ async fn run() {
     };
     surface.configure(&device, &config);
 
-    let atlas = TextAtlas::new(&device, &queue, swapchain_format);
-    let mut text_renderer = TextRenderer::new(&device, &queue, &atlas);
+    let mut atlas = TextAtlas::new(&device, &queue, swapchain_format);
+    let mut text_renderer = TextRenderer::new(&device, &queue);
 
     let font = include_bytes!("./Inter-Bold.ttf") as &[u8];
     let font = Font::from_bytes(font, FontSettings::default()).unwrap();
@@ -110,6 +110,7 @@ async fn run() {
                     .prepare(
                         &device,
                         &queue,
+                        &mut atlas,
                         Resolution {
                             width: config.width,
                             height: config.height,
@@ -137,7 +138,7 @@ async fn run() {
                         depth_stencil_attachment: None,
                     });
 
-                    text_renderer.render(&mut pass).unwrap();
+                    text_renderer.render(&atlas, &mut pass).unwrap();
                 }
 
                 queue.submit(Some(encoder.finish()));


### PR DESCRIPTION
Removes the internal `RwLock` in favor of accepting `&mut TextAtlas` (follow-up from https://github.com/grovesNL/glyphon/pull/9#issuecomment-1137501663)