### PR TITLE
Pad to improve WebGL support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub struct Resolution {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Params {
     screen_resolution: Resolution,
+    _pad: [u32; 2],
 }
 
 fn try_allocate(atlas: &mut TextAtlas, width: usize, height: usize) -> Option<Allocation> {
@@ -238,6 +239,7 @@ impl TextAtlas {
                 width: 0,
                 height: 0,
             },
+            _pad: [0, 0],
         };
 
         let params_buffer = device.create_buffer(&BufferDescriptor {


### PR DESCRIPTION
Better support WebGL by padding uniform block to 16-byte alignment, which will usually cause the block size to match `UNIFORM_BLOCK_DATA_SIZE` on WebGL.

We might be able to remove this or handle it differently eventually depending on how it's supported upstream.

(see https://github.com/gfx-rs/wgpu/issues/2072#issuecomment-1147599245 for more context)