### PR TITLE
Pad `Params` in shader

### DIFF
--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -14,6 +14,7 @@ struct VertexOutput {
 
 struct Params {
     screen_resolution: vec2<u32>,
+    _pad: vec2<u32>,
 };
 
 @group(0) @binding(0)


### PR DESCRIPTION
This is needed for the new WebGL2 16-byte alignment downlevel check in wgpu 0.13