### PR TITLE
Set renderer multisample and depth-stencil state

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -4,9 +4,9 @@ use glyphon::{
 };
 use wgpu::{
     Backends, CommandEncoderDescriptor, CompositeAlphaMode, DeviceDescriptor, Features, Instance,
-    Limits, LoadOp, Operations, PresentMode, RenderPassColorAttachment, RenderPassDescriptor,
-    RequestAdapterOptions, SurfaceConfiguration, TextureFormat, TextureUsages,
-    TextureViewDescriptor,
+    Limits, LoadOp, MultisampleState, Operations, PresentMode, RenderPassColorAttachment,
+    RenderPassDescriptor, RequestAdapterOptions, SurfaceConfiguration, TextureFormat,
+    TextureUsages, TextureViewDescriptor,
 };
 use winit::{
     dpi::LogicalSize,
@@ -64,12 +64,13 @@ async fn run() {
     surface.configure(&device, &config);
 
     // Set up text renderer
-    let mut text_renderer = TextRenderer::new(&device, &queue);
     unsafe {
         FONT_SYSTEM = Some(FontSystem::new());
     }
     let mut cache = SwashCache::new(unsafe { FONT_SYSTEM.as_ref().unwrap() });
     let mut atlas = TextAtlas::new(&device, &queue, swapchain_format);
+    let mut text_renderer =
+        TextRenderer::new(&mut atlas, &device, MultisampleState::default(), None);
     let mut buffer = Buffer::new(
         unsafe { FONT_SYSTEM.as_ref().unwrap() },
         Metrics::new(30, 42),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) struct GlyphToRender {
     uv: [u16; 2],
     color: u32,
     content_type: u32,
+    depth: f32,
 }
 
 /// The screen resolution to use when rendering text.

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -5,10 +5,11 @@ struct VertexInput {
     @location(2) uv: u32,
     @location(3) color: u32,
     @location(4) content_type: u32,
+    @location(5) depth: f32,
 }
 
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
+    @invariant @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
     @location(1) uv: vec2<f32>,
     @location(2) content_type: u32,
@@ -62,7 +63,7 @@ fn vs_main(in_vert: VertexInput) -> VertexOutput {
 
     vert_output.position = vec4<f32>(
         2.0 * vec2<f32>(pos) / vec2<f32>(params.screen_resolution) - 1.0,
-        0.0,
+        in_vert.depth,
         1.0,
     );
 

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -151,6 +151,11 @@ impl TextAtlas {
                     offset: size_of::<u32>() as u64 * 5,
                     shader_location: 4,
                 },
+                wgpu::VertexAttribute {
+                    format: VertexFormat::Float32,
+                    offset: size_of::<u32>() as u64 * 6,
+                    shader_location: 5,
+                },
             ],
         }];
 


### PR DESCRIPTION
Alternative fix to #25 that also includes depth-stencil state, so we can fit the pipeline into more existing renderpasses