### PR TITLE
Use `Srgb` texture format for `TextAtlas`

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -51,8 +51,7 @@ async fn run() {
         .await
         .unwrap();
     let surface = unsafe { instance.create_surface(&window) };
-    // TODO: handle srgb
-    let swapchain_format = TextureFormat::Bgra8Unorm;
+    let swapchain_format = TextureFormat::Bgra8UnormSrgb;
     let mut config = SurfaceConfiguration {
         usage: TextureUsages::RENDER_ATTACHMENT,
         format: swapchain_format,

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -46,7 +46,7 @@ impl InnerAtlas {
             dimension: TextureDimension::D2,
             format: match num_atlas_channels {
                 1 => TextureFormat::R8Unorm,
-                4 => TextureFormat::Rgba8Unorm,
+                4 => TextureFormat::Rgba8UnormSrgb,
                 _ => panic!("unexpected number of channels"),
             },
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,


### PR DESCRIPTION
Noticed colors produced by `swash` are already in the sRGB color space.