### PR TITLE
Make `render` take an immutable `self`

### DIFF
--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -431,7 +431,7 @@ impl TextRenderer {
 
     /// Renders all layouts that were previously provided to `prepare`.
     pub fn render<'pass>(
-        &'pass mut self,
+        &'pass self,
         atlas: &'pass TextAtlas,
         pass: &mut RenderPass<'pass>,
     ) -> Result<(), RenderError> {


### PR DESCRIPTION
Not sure if this was for future-proofing the API, but an immutable `render` is necessary to issue multiple out-of-order `render` calls on the same `pass` if you have a collection of `TextRenderer`.