### PR TITLE
Doc: Add small summary of crate goal in doc.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Glyphon provides a simple way to render 2D text with [wpgu], [cosmic-text] and [etagere].
+//!
+//! [wpgu]: https://github.com/gfx-rs/wgpu
+//! [cosmic-text]: https://github.com/pop-os/cosmic-text
+//! [etagere]: https://github.com/nical/etagere
+
 mod error;
 mod text_atlas;
 mod text_render;


### PR DESCRIPTION
This PR just adds a tiny summary of the goal of the crate for the doc.rs page.