### PR TITLE
Subpixel glyph positioning and scaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [dependencies]
 wgpu = "0.16"
 etagere = "0.2.8"
-cosmic-text = "0.8"
+cosmic-text = "0.9"
 lru = "0.9"
 
 [dev-dependencies]

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,6 +1,6 @@
 use glyphon::{
-    Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, SwashCache, TextArea, TextAtlas,
-    TextBounds, TextRenderer,
+    Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache, TextArea,
+    TextAtlas, TextBounds, TextRenderer,
 };
 use wgpu::{
     CommandEncoderDescriptor, CompositeAlphaMode, DeviceDescriptor, Features, Instance,
@@ -73,7 +73,7 @@ async fn run() {
     let physical_height = (height as f64 * scale_factor) as f32;
 
     buffer.set_size(&mut font_system, physical_width, physical_height);
-    buffer.set_text(&mut font_system, "Hello world! 👋\nThis is rendered with 🦅 glyphon 🦁\nThe text below should be partially clipped.\na b c d e f g h i j k l m n o p q r s t u v w x y z", Attrs::new().family(Family::SansSerif));
+    buffer.set_text(&mut font_system, "Hello world! 👋\nThis is rendered with 🦅 glyphon 🦁\nThe text below should be partially clipped.\na b c d e f g h i j k l m n o p q r s t u v w x y z", Attrs::new().family(Family::SansSerif), Shaping::Advanced);
     buffer.shape_until_scroll(&mut font_system);
 
     event_loop.run(move |event, _, control_flow| {
@@ -103,8 +103,9 @@ async fn run() {
                         },
                         [TextArea {
                             buffer: &buffer,
-                            left: 10,
-                            top: 10,
+                            left: 10.0,
+                            top: 10.0,
+                            scale: 1.0,
                             bounds: TextBounds {
                                 left: 0,
                                 top: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ pub use cosmic_text::{
     self, fontdb, Action, Affinity, Attrs, AttrsList, AttrsOwned, Buffer, BufferLine, CacheKey,
     Color, Command, Cursor, Edit, Editor, Family, FamilyOwned, Font, FontSystem, LayoutCursor,
     LayoutGlyph, LayoutLine, LayoutRun, LayoutRunIter, Metrics, ShapeGlyph, ShapeLine, ShapeSpan,
-    ShapeWord, Stretch, Style, SubpixelBin, SwashCache, SwashContent, SwashImage, Weight, Wrap,
+    ShapeWord, Shaping, Stretch, Style, SubpixelBin, SwashCache, SwashContent, SwashImage, Weight,
+    Wrap,
 };
 
 use etagere::AllocId;
@@ -101,9 +102,11 @@ pub struct TextArea<'a> {
     /// The buffer containing the text to be rendered.
     pub buffer: &'a Buffer,
     /// The left edge of the buffer.
-    pub left: i32,
+    pub left: f32,
     /// The top edge of the buffer.
-    pub top: i32,
+    pub top: f32,
+    /// The scaling to apply to the buffer.
+    pub scale: f32,
     /// The visible bounds of the text area. This is used to clip the text and doesn't have to
     /// match the `left` and `top` values.
     pub bounds: TextBounds,


### PR DESCRIPTION
Depends on #31.

The latest `cosmic-text` release performs bucketing calculations after layouting. This allows us to provide proper subpixel offsets, as well as scale any buffer thanks to its linear layout properties.

See https://github.com/pop-os/cosmic-text/pull/143.

Closes #3.