### PR TITLE
Add Interpolation attribute for the VertexOutput and add Error trait implementation for RenderError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,3 +40,5 @@ impl Display for RenderError {
         }
     }
 }
+
+impl Error for RenderError {}

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
     @invariant @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
     @location(1) uv: vec2<f32>,
-    @location(2) content_type: u32,
+    @location(2) @interpolate(flat) content_type: u32,
 };
 
 struct Params {


### PR DESCRIPTION
Hi, 
just two simple changes.

Without the interpolation attribute I got errors when compiling the shaders when running in a browser. 

> (User-defined [vertex](https://www.w3.org/TR/WGSL/#vertex) outputs and [fragment](https://www.w3.org/TR/WGSL/#fragment) inputs of scalar or vector integer type [must](https://www.w3.org/TR/WGSL/#shader-creation-error) always be specified as @interpolate(flat).)

from https://www.w3.org/TR/WGSL/#interpolation

I also noticed the missing impl Error with RenderError. If that was intentional feel free to revert.