### PR TITLE
Bump `winit` to `0.28.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ cosmic-text = "0.9"
 lru = "0.11"
 
 [dev-dependencies]
-winit = "0.28.0"
+winit = "0.28.7"
 pollster = "0.3.0"


### PR DESCRIPTION
This version of `winit` solves a problem related to MacOS Sonoma.
See: https://github.com/rust-windowing/winit/issues/2876