### PR TITLE
Add TextArea.transform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ wgpu = "0.18"
 etagere = "0.2.8"
 cosmic-text = "0.10"
 lru = "0.11"
+glam = "0.24.2"
 
 [dev-dependencies]
 winit = "0.28.7"

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::PI;
+
 use glyphon::{
     Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache, TextArea,
     TextAtlas, TextBounds, TextRenderer,
@@ -113,9 +115,9 @@ async fn run() {
                                 bottom: 160,
                             },
                             default_color: Color::rgb(255, 255, 255),
-                            // transform: glyphon::Mat3::IDENTITY,
-                            transform: glyphon::Mat3::from_angle(0.5)
-                                * glyphon::Mat3::from_translation(glam::Vec2::new(200.0, 20.0)),
+                            transform: glyphon::Mat3::IDENTITY,
+                            // transform: glyphon::Mat3::from_angle(PI / 2.0)
+                            //     * glyphon::Mat3::from_translation(glam::Vec2::new(200.0, -200.0)),
                         }],
                         &mut cache,
                     )

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -113,6 +113,9 @@ async fn run() {
                                 bottom: 160,
                             },
                             default_color: Color::rgb(255, 255, 255),
+                            // transform: glyphon::Mat3::IDENTITY,
+                            transform: glyphon::Mat3::from_angle(0.5)
+                                * glyphon::Mat3::from_translation(glam::Vec2::new(200.0, 20.0)),
                         }],
                         &mut cache,
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use cosmic_text::{
     ShapeWord, Shaping, Stretch, Style, SubpixelBin, SwashCache, SwashContent, SwashImage, Weight,
     Wrap,
 };
+pub use glam::Mat3;
 
 use etagere::AllocId;
 
@@ -46,8 +47,7 @@ pub(crate) struct GlyphDetails {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct GlyphToRender {
-    pos: [i32; 2],
-    dim: [u16; 2],
+    pos: glam::IVec2,
     uv: [u16; 2],
     color: u32,
     content_type: u32,
@@ -112,4 +112,6 @@ pub struct TextArea<'a> {
     pub bounds: TextBounds,
     // The default color of the text area.
     pub default_color: Color,
+    /// The 2D transformation
+    pub transform: Mat3,
 }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,11 +1,10 @@
 struct VertexInput {
     @builtin(vertex_index) vertex_idx: u32,
     @location(0) pos: vec2<i32>,
-    @location(1) dim: u32,
-    @location(2) uv: u32,
-    @location(3) color: u32,
-    @location(4) content_type: u32,
-    @location(5) depth: f32,
+    @location(1) uv: u32,
+    @location(2) color: u32,
+    @location(3) content_type: u32,
+    @location(4) depth: f32,
 }
 
 struct VertexOutput {
@@ -35,32 +34,10 @@ var atlas_sampler: sampler;
 @vertex
 fn vs_main(in_vert: VertexInput) -> VertexOutput {
     var pos = in_vert.pos;
-    let width = in_vert.dim & 0xffffu;
-    let height = (in_vert.dim & 0xffff0000u) >> 16u;
     let color = in_vert.color;
     var uv = vec2<u32>(in_vert.uv & 0xffffu, (in_vert.uv & 0xffff0000u) >> 16u);
     let v = in_vert.vertex_idx % 4u;
-
-    switch v {
-        case 1u: {
-            pos.x += i32(width);
-            uv.x += width;
-        }
-        case 2u: {
-            pos.x += i32(width);
-            pos.y += i32(height);
-            uv.x += width;
-            uv.y += height;
-        }
-        case 3u: {
-            pos.y += i32(height);
-            uv.y += height;
-        }
-        default: {}
-    }
-
     var vert_output: VertexOutput;
-
     vert_output.position = vec4<f32>(
         2.0 * vec2<f32>(pos) / vec2<f32>(params.screen_resolution) - 1.0,
         in_vert.depth,

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -325,14 +325,9 @@ impl TextAtlas {
                     shader_location: 3,
                 },
                 wgpu::VertexAttribute {
-                    format: VertexFormat::Uint32,
+                    format: VertexFormat::Float32,
                     offset: size_of::<u32>() as u64 * 5,
                     shader_location: 4,
-                },
-                wgpu::VertexAttribute {
-                    format: VertexFormat::Float32,
-                    offset: size_of::<u32>() as u64 * 6,
-                    shader_location: 5,
                 },
             ],
         }];


### PR DESCRIPTION
This PR adds `transform: Mat3` to TextArea so that a user can provide any transform.
There is no subpixel handling but looks clean on 90/180/270 rotations.

![Screenshot from 2023-11-20 00-17-12](https://github.com/grovesNL/glyphon/assets/1851290/60d29838-bcaa-4f3c-848a-c149f16bcc2c)

![Screenshot from 2023-11-20 01-26-24](https://github.com/grovesNL/glyphon/assets/1851290/502f82d4-5f88-4bb5-b708-bb3dc01df520)
