### PR TITLE
Fixed Clippy and Cargo warnings

### DIFF
--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -87,7 +87,7 @@ impl InnerAtlas {
             // Find a glyph with an actual size
             while value.atlas_id.is_none() {
                 // All sized glyphs are in use, cache is full
-                if self.glyphs_in_use.contains(&key) {
+                if self.glyphs_in_use.contains(key) {
                     return None;
                 }
 
@@ -97,7 +97,7 @@ impl InnerAtlas {
             }
 
             // All sized glyphs are in use, cache is full
-            if self.glyphs_in_use.contains(&key) {
+            if self.glyphs_in_use.contains(key) {
                 return None;
             }
 

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -306,7 +306,7 @@ impl TextRenderer {
         let vertices_raw = unsafe {
             slice::from_raw_parts(
                 vertices as *const _ as *const u8,
-                size_of::<GlyphToRender>() * vertices.len(),
+                std::mem::size_of_val(vertices),
             )
         };
 
@@ -330,7 +330,7 @@ impl TextRenderer {
         let indices_raw = unsafe {
             slice::from_raw_parts(
                 indices as *const _ as *const u8,
-                size_of::<u32>() * indices.len(),
+                std::mem::size_of_val(indices),
             )
         };
 

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -109,8 +109,11 @@ impl TextRenderer {
                     {
                         atlas.color_atlas.promote(physical_glyph.cache_key);
                     } else {
-                        let Some(image) = cache
-                            .get_image_uncached(font_system, physical_glyph.cache_key) else { continue };
+                        let Some(image) =
+                            cache.get_image_uncached(font_system, physical_glyph.cache_key)
+                        else {
+                            continue;
+                        };
 
                         let content_type = match image.content {
                             SwashContent::Color => ContentType::Color,


### PR DESCRIPTION
I was fixing up my own project when I noticed there were some clippy warnings about Glyphon. I did not fix the too many arguments issue as not much can be done about that.