### PR TITLE
Add `#[doc(no_inline)]` to cosmic-text reexports 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Glyphon provides a simple way to render 2D text with [wpgu], [cosmic-text] and [etagere].
+//! Glyphon provides a simple way to render 2D text with [wgpu], [cosmic-text] and [etagere].
 //!
 //! [wpgu]: https://github.com/gfx-rs/wgpu
 //! [cosmic-text]: https://github.com/pop-os/cosmic-text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use text_render::TextRenderer;
 use text_render::ContentType;
 
 // Re-export all top-level types from `cosmic-text` for convenience.
+#[doc(no_inline)]
 pub use cosmic_text::{
     self, fontdb, Action, Affinity, Attrs, AttrsList, AttrsOwned, Buffer, BufferLine, CacheKey,
     Color, Command, Cursor, Edit, Editor, Family, FamilyOwned, Font, FontSystem, LayoutCursor,


### PR DESCRIPTION
Before this commit, all reexported symbols were displayed as if they were part of `glyphon` directly. Users not being able to see at a glance what's part of which crate has a few disadvantages. It makes understanding the whole stack more difficult, since it's unclear what's part of the wgpu-integration and what's part of the general text handling. Personally, I also think this can deter people from using glyphon as this makes the crate (which is "just" the wgpu integration) seem huge. Finally, some symbols in the docs were not linked (as if it was private), which is also really bad for browsing docs.