### PR TITLE
Don't convert web text colors to linear

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub(crate) struct GlyphToRender {
     dim: [u16; 2],
     uv: [u16; 2],
     color: u32,
-    content_type: u32,
+    content_type_with_srgb: [u16; 2],
     depth: f32,
 }
 

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -271,6 +271,7 @@ pub struct TextAtlas {
     pub(crate) shader: ShaderModule,
     pub(crate) vertex_buffers: [wgpu::VertexBufferLayout<'static>; 1],
     pub(crate) format: TextureFormat,
+    pub(crate) color_mode: ColorMode,
 }
 
 impl TextAtlas {
@@ -450,6 +451,7 @@ impl TextAtlas {
             shader,
             vertex_buffers,
             format,
+            color_mode,
         }
     }
 


### PR DESCRIPTION
Use the `color_mode` from the atlas to decide whether colors should be converted to linear per vertex.

This should address the review comment at https://github.com/grovesNL/glyphon/pull/75#pullrequestreview-1822316027

I kept the calculation on the GPU for now because it gives us slightly better precision for the linear colors (e.g., for blending), but there's a minor trade-off there.

@hecrj could you check this against your test case (or let me know how to run it)? Thank you!