### PR TITLE
Do a little feature magic to allow to build for web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/grovesNL/glyphon"
 license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
-wgpu = { version = "0.19", default-features = false }
+wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
 cosmic-text = "0.10"
 lru = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ lru = "0.12.1"
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }
 pollster = "0.3.0"
-
-[features]
-default = ["wgpu/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ lru = "0.12.1"
 
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }
+wgpu = { version = "0.19", default-features = true }
 pollster = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/grovesNL/glyphon"
 license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
-wgpu = "0.19"
+wgpu = { version = "0.19", default-features = false }
 etagere = "0.2.10"
 cosmic-text = "0.10"
 lru = "0.12.1"
@@ -16,3 +16,6 @@ lru = "0.12.1"
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }
 pollster = "0.3.0"
+
+[features]
+default = ["wgpu/default"]


### PR DESCRIPTION
This change will allow people who want to build this crate for web (especially today) to do so, by allowing them to
transitively turn off the default wgpu features.

Turning it back on would be this crate's default feature, so current consumers wouldn't have to change anything, but
people who want web now can now do:

```toml
[dependencies]
# ... really cool deps ...
glyphon = { version = "0.5.0-whatever", default-features = false }
wgpu = { version = "0.19.1-cool-beans", default-features = false, features = ["webgl"] }
```