### PR TITLE
Camera/Screen transformation support

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,6 +1,6 @@
 use glyphon::{
-    Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache, TextArea,
-    TextAtlas, TextBounds, TextRenderer,
+    Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Screen, Shaping, SwashCache,
+    TextArea, TextAtlas, TextBounds, TextRenderer,
 };
 use wgpu::{
     CommandEncoderDescriptor, CompositeAlphaMode, DeviceDescriptor, Features, Instance,
@@ -25,11 +25,13 @@ async fn run() {
     // Set up window
     let (width, height) = (800, 600);
     let event_loop = EventLoop::new().unwrap();
-    let window = Arc::new(WindowBuilder::new()
-        .with_inner_size(LogicalSize::new(width as f64, height as f64))
-        .with_title("glyphon hello world")
-        .build(&event_loop)
-        .unwrap());
+    let window = Arc::new(
+        WindowBuilder::new()
+            .with_inner_size(LogicalSize::new(width as f64, height as f64))
+            .with_title("glyphon hello world")
+            .build(&event_loop)
+            .unwrap(),
+    );
     let size = window.inner_size();
     let scale_factor = window.scale_factor();
 
@@ -51,7 +53,9 @@ async fn run() {
         .await
         .unwrap();
 
-    let surface = instance.create_surface(window.clone()).expect("Create surface");
+    let surface = instance
+        .create_surface(window.clone())
+        .expect("Create surface");
     let swapchain_format = TextureFormat::Bgra8UnormSrgb;
     let mut config = SurfaceConfiguration {
         usage: TextureUsages::RENDER_ATTACHMENT,
@@ -101,10 +105,10 @@ async fn run() {
                                 &queue,
                                 &mut font_system,
                                 &mut atlas,
-                                Resolution {
+                                Screen::Resolution(Resolution {
                                     width: config.width,
                                     height: config.height,
-                                },
+                                }),
                                 [TextArea {
                                     buffer: &buffer,
                                     left: 10.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,34 @@ pub(crate) struct GlyphToRender {
     depth: f32,
 }
 
+#[derive(Clone, Debug)]
+pub enum Screen {
+    Resolution(Resolution),
+    CustomTransformation(Matrix),
+}
+
+impl Screen {
+    fn matrix(&self) -> Matrix {
+        match self {
+            Screen::Resolution(resolution) => {
+                #[rustfmt::skip]
+                let matrix = [
+                    [2. / resolution.width as f32,                             0., -1.0],
+                    [                           0., 2. / resolution.height as f32, -1.0],
+                    [                           0.,                            0.,  1.0],
+                ];
+                Matrix { matrix }
+            }
+            Screen::CustomTransformation(matrix) => *matrix,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Matrix {
+    pub matrix: [[f32; 3]; 3],
+}
+
 /// The screen resolution to use when rendering text.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -66,10 +94,31 @@ pub struct Resolution {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub(crate) struct Params {
-    screen_resolution: Resolution,
-    _pad: [u32; 2],
+    transform: [f32; (3 + 1) * 3],
+}
+
+impl From<&Screen> for Params {
+    fn from(value: &Screen) -> Self {
+        value.matrix().into()
+    }
+}
+
+impl From<Matrix> for Params {
+    fn from(value: Matrix) -> Self {
+        Self {
+            // wgsl matrix is column-major
+            transform: std::array::from_fn(|idx| {
+                let row = idx % 4;
+                if row == 3 {
+                    0.
+                } else {
+                    value.matrix[row][idx / 4]
+                }
+            }),
+        }
+    }
 }
 
 /// Controls the visible area of the text. Any text outside of the visible area will be clipped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,11 @@ impl From<Matrix> for Params {
             // wgsl matrix is column-major
             transform: std::array::from_fn(|idx| {
                 let row = idx % 4;
+                let col = idx / 4;
                 if row == 3 {
                     0.
                 } else {
-                    value.matrix[row][idx / 4]
+                    value.matrix[row][col]
                 }
             }),
         }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -22,13 +22,13 @@ struct Params {
 @group(0) @binding(0)
 var<uniform> params: Params;
 
-@group(0) @binding(1)
+@group(1) @binding(0)
 var color_atlas_texture: texture_2d<f32>;
 
-@group(0) @binding(2)
+@group(1) @binding(1)
 var mask_atlas_texture: texture_2d<f32>;
 
-@group(0) @binding(3)
+@group(1) @binding(2)
 var atlas_sampler: sampler;
 
 fn srgb_to_linear(c: f32) -> f32 {
@@ -69,7 +69,7 @@ fn vs_main(in_vert: VertexInput) -> VertexOutput {
     var vert_output: VertexOutput;
 
     vert_output.position = vec4<f32>(
-        (vec3<f32>(vec2<f32>(pos), 1.0) * params.transform).xy,
+        (params.transform * vec3<f32>(vec2<f32>(pos), 1.0)).xy,
         in_vert.depth,
         1.0,
     );

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -16,8 +16,7 @@ struct VertexOutput {
 };
 
 struct Params {
-    screen_resolution: vec2<u32>,
-    _pad: vec2<u32>,
+    transform: mat3x3<f32>,
 };
 
 @group(0) @binding(0)
@@ -70,7 +69,7 @@ fn vs_main(in_vert: VertexInput) -> VertexOutput {
     var vert_output: VertexOutput;
 
     vert_output.position = vec4<f32>(
-        2.0 * vec2<f32>(pos) / vec2<f32>(params.screen_resolution) - 1.0,
+        (vec3<f32>(vec2<f32>(pos), 1.0) * params.transform).xy,
         in_vert.depth,
         1.0,
     );

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -1,6 +1,6 @@
 use crate::{
     text_render::ContentType, CacheKey, FontSystem, GlyphDetails, GlyphToRender, GpuCacheStatus,
-    Params, Resolution, SwashCache,
+    Params, SwashCache,
 };
 use etagere::{size2, Allocation, BucketedAtlasAllocator};
 use lru::LruCache;
@@ -340,6 +340,7 @@ impl TextAtlas {
             ],
         }];
 
+        println!("{}", size_of::<Params>() as u64);
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[
                 BindGroupLayoutEntry {
@@ -382,13 +383,7 @@ impl TextAtlas {
             label: Some("glyphon bind group layout"),
         });
 
-        let params = Params {
-            screen_resolution: Resolution {
-                width: 0,
-                height: 0,
-            },
-            _pad: [0, 0],
-        };
+        let params = Params::default();
 
         let params_buffer = device.create_buffer(&BufferDescriptor {
             label: Some("glyphon params"),

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -4,13 +4,15 @@ use crate::{
 };
 use std::{iter, mem::size_of, slice, sync::Arc};
 use wgpu::{
-    Buffer, BufferDescriptor, BufferUsages, DepthStencilState, Device, Extent3d, ImageCopyTexture,
-    ImageDataLayout, IndexFormat, MultisampleState, Origin3d, Queue, RenderPass, RenderPipeline,
-    TextureAspect, COPY_BUFFER_ALIGNMENT,
+    BindGroupDescriptor, BindGroupEntry, Buffer, BufferDescriptor, BufferUsages, DepthStencilState,
+    Device, Extent3d, ImageCopyTexture, ImageDataLayout, IndexFormat, MultisampleState, Origin3d,
+    Queue, RenderPass, RenderPipeline, TextureAspect, COPY_BUFFER_ALIGNMENT,
 };
 
 /// A text renderer that uses cached glyphs to render text into an existing render pass.
 pub struct TextRenderer {
+    params: Params,
+    params_buffer: Buffer,
     vertex_buffer: Buffer,
     vertex_buffer_size: u64,
     index_buffer: Buffer,
@@ -18,6 +20,7 @@ pub struct TextRenderer {
     vertices_to_render: u32,
     screen: Screen,
     pipeline: Arc<RenderPipeline>,
+    bind_group: wgpu::BindGroup,
 }
 
 impl TextRenderer {
@@ -46,7 +49,27 @@ impl TextRenderer {
 
         let pipeline = atlas.get_or_create_pipeline(device, multisample, depth_stencil);
 
+        let params = Params::default();
+
+        let params_buffer = device.create_buffer(&BufferDescriptor {
+            label: Some("glyphon params"),
+            size: size_of::<Params>() as u64,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            layout: &atlas.text_render_bind_group_layout,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: params_buffer.as_entire_binding(),
+            }],
+            label: Some("glyphon text render bind group"),
+        });
+
         Self {
+            params,
+            params_buffer,
             vertex_buffer,
             vertex_buffer_size,
             index_buffer,
@@ -57,6 +80,7 @@ impl TextRenderer {
                 height: 0,
             }),
             pipeline,
+            bind_group,
         }
     }
 
@@ -76,11 +100,11 @@ impl TextRenderer {
 
         let current_params = self.screen.matrix().into();
 
-        if current_params != atlas.params {
-            atlas.params = current_params;
-            queue.write_buffer(&atlas.params_buffer, 0, unsafe {
+        if current_params != self.params {
+            self.params = current_params;
+            queue.write_buffer(&self.params_buffer, 0, unsafe {
                 slice::from_raw_parts(
-                    &atlas.params as *const Params as *const u8,
+                    &self.params as *const Params as *const u8,
                     size_of::<Params>(),
                 )
             });
@@ -396,15 +420,9 @@ impl TextRenderer {
             return Ok(());
         }
 
-        {
-            // Validate that screen resolution hasn't changed since `prepare`
-            if Params::from(&self.screen) != atlas.params {
-                return Err(RenderError::ScreenResolutionChanged);
-            }
-        }
-
         pass.set_pipeline(&self.pipeline);
-        pass.set_bind_group(0, &atlas.bind_group, &[]);
+        pass.set_bind_group(0, &self.bind_group, &[]);
+        pass.set_bind_group(1, &atlas.bind_group, &[]);
         pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         pass.set_index_buffer(self.index_buffer.slice(..), IndexFormat::Uint32);
         pass.draw_indexed(0..self.vertices_to_render, 0, 0..1);


### PR DESCRIPTION
Added some support for rendering text with custom 2D world transformations
https://github.com/grovesNL/glyphon/issues/4

Moved transformation matrix buffer to text_renderer to allow rendering multiple transformations of text and to be able to reuse the same texture atlas for all operations.

