### PR TITLE
Bump cosmic-text to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [dependencies]
 wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
-cosmic-text = "0.10"
+cosmic-text = "0.11"
 lru = "0.12.1"
 
 [dev-dependencies]

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -78,7 +78,7 @@ async fn run() {
 
     buffer.set_size(&mut font_system, physical_width, physical_height);
     buffer.set_text(&mut font_system, "Hello world! 👋\nThis is rendered with 🦅 glyphon 🦁\nThe text below should be partially clipped.\na b c d e f g h i j k l m n o p q r s t u v w x y z", Attrs::new().family(Family::SansSerif), Shaping::Advanced);
-    buffer.shape_until_scroll(&mut font_system);
+    buffer.shape_until_scroll(&mut font_system, false);
 
     event_loop
         .run(move |event, target| {


### PR DESCRIPTION
I needed some features from `cosmic-text` 0.11, so I bumped the version. The API barely changed, so the diff is minor.