### PR TITLE
Use `rustc-hash` for `HashSet` of `glyphs_in_use`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
 cosmic-text = "0.11"
 lru = { version = "0.12.1", default-features = false }
-ahash = "0.8"
+ahash = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
 cosmic-text = "0.11"
-lru = "0.12.1"
+lru = { version = "0.12.1", default-features = false }
 ahash = "0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
 cosmic-text = "0.11"
 lru = "0.12.1"
+ahash = "0.8"
 
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ wgpu = { version = "0.19", default-features = false, features = ["wgsl"] }
 etagere = "0.2.10"
 cosmic-text = "0.11"
 lru = { version = "0.12.1", default-features = false }
-ahash = { version = "0.8", default-features = false }
+rustc-hash = "1.1"
 
 [dev-dependencies]
 winit = { version = "0.29.10", features = ["rwh_05"] }

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -2,9 +2,9 @@ use crate::{
     text_render::ContentType, CacheKey, FontSystem, GlyphDetails, GlyphToRender, GpuCacheStatus,
     Params, SwashCache,
 };
-use ahash::AHasher;
 use etagere::{size2, Allocation, BucketedAtlasAllocator};
 use lru::LruCache;
+use rustc_hash::FxHasher;
 use std::{
     borrow::Cow, collections::HashSet, hash::BuildHasherDefault, mem::size_of, num::NonZeroU64,
     sync::Arc,
@@ -21,7 +21,7 @@ use wgpu::{
     VertexState,
 };
 
-type Hasher = BuildHasherDefault<AHasher>;
+type Hasher = BuildHasherDefault<FxHasher>;
 
 #[allow(dead_code)]
 pub(crate) struct InnerAtlas {

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -62,7 +62,7 @@ impl InnerAtlas {
 
         let texture_view = texture.create_view(&TextureViewDescriptor::default());
 
-        let glyph_cache = LruCache::unbounded();
+        let glyph_cache = LruCache::unbounded_with_hasher(Hasher::default());
         let glyphs_in_use = HashSet::with_hasher(Hasher::default());
 
         Self {


### PR DESCRIPTION
The `HashSet` of `glyphs_in_use` in the text atlas is using the default SipHash 1-3 hasher.

Switching to `ahash`, which is already used by the `LruCache`, increases performance a bit.

This seems to remove the `Hasher::write` calls in my flamegraphs:

<img width="635" alt="image" src="https://github.com/grovesNL/glyphon/assets/518289/b14762a6-4b03-441f-8f1f-b0f23efc64bc">

vs

<img width="637" alt="image" src="https://github.com/grovesNL/glyphon/assets/518289/3c20f7de-1d91-4eff-bff2-254d972cf134">

