### PR TITLE
Reuse `Vec` allocations in `TextRenderer`

### DIFF
--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -20,6 +20,8 @@ pub struct TextRenderer {
     vertices_to_render: u32,
     pipeline: Arc<RenderPipeline>,
     bind_group: wgpu::BindGroup,
+    glyph_vertices: Vec<GlyphToRender>,
+    glyph_indices: Vec<u32>,
 }
 
 impl TextRenderer {
@@ -82,6 +84,8 @@ impl TextRenderer {
             vertices_to_render: 0,
             pipeline,
             bind_group,
+            glyph_vertices: Vec::new(),
+            glyph_indices: Vec::new(),
         }
     }
 
@@ -107,8 +111,8 @@ impl TextRenderer {
             });
         }
 
-        let mut glyph_vertices: Vec<GlyphToRender> = Vec::new();
-        let mut glyph_indices: Vec<u32> = Vec::new();
+        self.glyph_vertices.clear();
+        self.glyph_indices.clear();
         let mut glyphs_added = 0;
 
         for text_area in text_areas {
@@ -291,7 +295,7 @@ impl TextRenderer {
 
                     let depth = metadata_to_depth(glyph.metadata);
 
-                    glyph_vertices.extend(
+                    self.glyph_vertices.extend(
                         iter::repeat(GlyphToRender {
                             pos: [x, y],
                             dim: [width as u16, height as u16],
@@ -310,7 +314,7 @@ impl TextRenderer {
                     );
 
                     let start = 4 * glyphs_added as u32;
-                    glyph_indices.extend([
+                    self.glyph_indices.extend([
                         start,
                         start + 1,
                         start + 2,
@@ -332,7 +336,7 @@ impl TextRenderer {
             return Ok(());
         }
 
-        let vertices = glyph_vertices.as_slice();
+        let vertices = self.glyph_vertices.as_slice();
         let vertices_raw = unsafe {
             slice::from_raw_parts(
                 vertices as *const _ as *const u8,
@@ -356,7 +360,7 @@ impl TextRenderer {
             self.vertex_buffer_size = buffer_size;
         }
 
-        let indices = glyph_indices.as_slice();
+        let indices = self.glyph_indices.as_slice();
         let indices_raw = unsafe {
             slice::from_raw_parts(
                 indices as *const _ as *const u8,


### PR DESCRIPTION
This avoids constantly reallocating the storage for the vertices and indices uploads.

Basically, it completely removes the initial bump here:

<img width="619" alt="image" src="https://github.com/grovesNL/glyphon/assets/518289/630c1a53-571b-47a5-a2ec-36a57df2c3a9">

When combined with #90, here's the result:

<img width="629" alt="image" src="https://github.com/grovesNL/glyphon/assets/518289/38d0b515-d2ab-4c86-8cf2-bab092f3bbb0">