### PR TITLE
Introduce explicit `Viewport` sharing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,13 @@ mod cache;
 mod error;
 mod text_atlas;
 mod text_render;
+mod viewport;
 
 pub use cache::Cache;
 pub use error::{PrepareError, RenderError};
 pub use text_atlas::{ColorMode, TextAtlas};
 pub use text_render::TextRenderer;
+pub use viewport::Viewport;
 
 use text_render::ContentType;
 

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -6,7 +6,7 @@ use lru::LruCache;
 use rustc_hash::FxHasher;
 use std::{collections::HashSet, hash::BuildHasherDefault, sync::Arc};
 use wgpu::{
-    BindGroup, Buffer, DepthStencilState, Device, Extent3d, ImageCopyTexture, ImageDataLayout,
+    BindGroup, DepthStencilState, Device, Extent3d, ImageCopyTexture, ImageDataLayout,
     MultisampleState, Origin3d, Queue, RenderPipeline, Texture, TextureAspect, TextureDescriptor,
     TextureDimension, TextureFormat, TextureUsages, TextureView, TextureViewDescriptor,
 };
@@ -348,10 +348,6 @@ impl TextAtlas {
     ) -> Arc<RenderPipeline> {
         self.cache
             .get_or_create_pipeline(device, self.format, multisample, depth_stencil)
-    }
-
-    pub(crate) fn create_uniforms_bind_group(&self, device: &Device, buffer: &Buffer) -> BindGroup {
-        self.cache.create_uniforms_bind_group(device, buffer)
     }
 
     fn rebind(&mut self, device: &wgpu::Device) {

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -1,0 +1,57 @@
+use crate::{Cache, Params, Resolution};
+
+use wgpu::{BindGroup, Buffer, BufferDescriptor, BufferUsages, Device, Queue};
+
+use std::mem;
+use std::slice;
+
+#[derive(Debug)]
+pub struct Viewport {
+    params: Params,
+    params_buffer: Buffer,
+    pub(crate) bind_group: BindGroup,
+}
+
+impl Viewport {
+    pub fn new(device: &Device, cache: &Cache) -> Self {
+        let params = Params {
+            screen_resolution: Resolution {
+                width: 0,
+                height: 0,
+            },
+            _pad: [0, 0],
+        };
+
+        let params_buffer = device.create_buffer(&BufferDescriptor {
+            label: Some("glyphon params"),
+            size: mem::size_of::<Params>() as u64,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group = cache.create_uniforms_bind_group(device, &params_buffer);
+
+        Self {
+            params,
+            params_buffer,
+            bind_group,
+        }
+    }
+
+    pub fn update(&mut self, queue: &Queue, resolution: Resolution) {
+        if self.params.screen_resolution != resolution {
+            self.params.screen_resolution = resolution;
+
+            queue.write_buffer(&self.params_buffer, 0, unsafe {
+                slice::from_raw_parts(
+                    &self.params as *const Params as *const u8,
+                    mem::size_of::<Params>(),
+                )
+            });
+        }
+    }
+
+    pub fn resolution(&self) -> Resolution {
+        self.params.screen_resolution
+    }
+}


### PR DESCRIPTION
This PR introduces a `Viewport` type that explicitly holds the `Params` of a `Pipeline`.

This allows sharing a `Viewport` with multiple `TextRenderer` instances, reducing pipeline context changes.

Depends on #95.