### PR TITLE
Only iterate on visible runs within textbounds

### DIFF
--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -60,7 +60,18 @@ impl TextRenderer {
         let resolution = viewport.resolution();
 
         for text_area in text_areas {
-            for run in text_area.buffer.layout_runs() {
+            let is_run_visible = |run: &cosmic_text::LayoutRun| {
+                let start_y = (text_area.top + run.line_top) as i32;
+                let end_y = (text_area.top + run.line_top + run.line_height) as i32;
+
+                start_y <= text_area.bounds.bottom && text_area.bounds.top <= end_y
+            };
+
+            let layout_runs = text_area.buffer.layout_runs()
+                .skip_while(|run| !is_run_visible(run))
+                .take_while(is_run_visible);
+
+            for run in layout_runs {
                 for glyph in run.glyphs.iter() {
                     let physical_glyph =
                         glyph.physical((text_area.left, text_area.top), text_area.scale);


### PR DESCRIPTION
Currently it seems that text is being clipped per glyph and if there are whole lines outside of the visible bounds, it'll still have to go through each glyph on each line. This can be really really slow with super long files

Without the changes in my iced app:
![image](https://github.com/user-attachments/assets/18ea2036-d2a9-43fc-bc35-9a474f7936b6)

With the changes:
![image](https://github.com/user-attachments/assets/1c92d516-bfd5-4382-a626-41ca4769e987)