### PR TITLE
Relax lifetimes on TextRenderer::render()

### DIFF
--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -331,11 +331,11 @@ impl TextRenderer {
     }
 
     /// Renders all layouts that were previously provided to `prepare`.
-    pub fn render<'s, 'pass>(
-        &'s self,
-        atlas: &'s TextAtlas,
-        viewport: &'s Viewport,
-        pass: &mut RenderPass<'pass>,
+    pub fn render(
+        &self,
+        atlas: &TextAtlas,
+        viewport: &Viewport,
+        pass: &mut RenderPass<'_>,
     ) -> Result<(), RenderError> {
         if self.glyph_vertices.is_empty() {
             return Ok(());

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -331,10 +331,10 @@ impl TextRenderer {
     }
 
     /// Renders all layouts that were previously provided to `prepare`.
-    pub fn render<'pass>(
-        &'pass self,
-        atlas: &'pass TextAtlas,
-        viewport: &'pass Viewport,
+    pub fn render<'s, 'pass>(
+        &'s self,
+        atlas: &'s TextAtlas,
+        viewport: &'s Viewport,
         pass: &mut RenderPass<'pass>,
     ) -> Result<(), RenderError> {
         if self.glyph_vertices.is_empty() {


### PR DESCRIPTION
The method's lifetimes are far too restrictive, which makes the method really annoying to use. I'm not sure if you have any plans to make use of these restrictions in the future, but I don't see why you would need to.