### PR TITLE
Fix the `is_run_visible` calculation

### DIFF
--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -225,7 +225,7 @@ impl TextRenderer {
             }
 
             let is_run_visible = |run: &cosmic_text::LayoutRun| {
-                let start_y_physical = text_area.top + (run.line_top * text_area.scale) as i32;
+                let start_y_physical = (text_area.top + (run.line_top * text_area.scale)) as i32;
                 let end_y_physical = start_y_physical + (run.line_height * text_area.scale) as i32;
                 
                 start_y_physical <= text_area.bounds.bottom && text_area.bounds.top <= end_y_physical

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -225,12 +225,10 @@ impl TextRenderer {
             }
 
             let is_run_visible = |run: &cosmic_text::LayoutRun| {
-                let start_y = (text_area.top + (run.line_top * text_area.scale)) as i32;
-                let end_y = (text_area.top
-                    + (run.line_top * text_area.scale)
-                    + (run.line_height * text_area.scale)) as i32;
-
-                start_y <= text_area.bounds.bottom && text_area.bounds.top <= end_y
+                let start_y_physical = text_area.top + (run.line_top * text_area.scale);
+                let end_y_physical = start_y_physical + (run.line_height * text_area.scale);
+                
+                start_y_physical <= text_area.bounds.bottom && text_area.bounds.top <= end_y_physical
             };
 
             let layout_runs = text_area

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -225,8 +225,8 @@ impl TextRenderer {
             }
 
             let is_run_visible = |run: &cosmic_text::LayoutRun| {
-                let start_y_physical = text_area.top + (run.line_top * text_area.scale);
-                let end_y_physical = start_y_physical + (run.line_height * text_area.scale);
+                let start_y_physical = text_area.top + (run.line_top * text_area.scale) as i32;
+                let end_y_physical = start_y_physical + (run.line_height * text_area.scale) as i32;
                 
                 start_y_physical <= text_area.bounds.bottom && text_area.bounds.top <= end_y_physical
             };

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -225,8 +225,10 @@ impl TextRenderer {
             }
 
             let is_run_visible = |run: &cosmic_text::LayoutRun| {
-                let start_y = (text_area.top + run.line_top) as i32;
-                let end_y = (text_area.top + run.line_top + run.line_height) as i32;
+                let start_y = (text_area.top + (run.line_top * text_area.scale)) as i32;
+                let end_y = (text_area.top
+                    + (run.line_top * text_area.scale)
+                    + (run.line_height * text_area.scale)) as i32;
 
                 start_y <= text_area.bounds.bottom && text_area.bounds.top <= end_y
             };


### PR DESCRIPTION
I'm fairly sure this calculation isn't correct (thought I may be wrong). If I recall correctly, the `text_area` bounds are supposed to be in physical pixels, while the `run_line` is in logical pixels.

In a nutshell, my program had problems before this fix, now it doesn't.